### PR TITLE
Added ant buildfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin
+dist

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<project name="MCPMappingViewer" default="main" basedir=".">
+	<property name="src.dir" location="src" />
+	<property name="build.dir" location="bin" />
+	<property name="dist.dir" location="dist" />
+	<property name="dist.jarname" value="MCPMappingViewer.jar" />
+	<property name="manifest.mainclass" value="bspkrs.mmv.gui.MappingGui" />
+
+	<target name="clean">
+		<delete dir="${build.dir}" failonerror="false" />
+		<delete dir="${dist.dir}" failonerror="false" />
+	</target>
+
+	<target name="prepare" depends="clean">
+		<mkdir dir="${build.dir}" />
+		<mkdir dir="${dist.dir}" />
+	</target>
+
+	<target name="compile" depends="prepare" description="Compile">
+		<javac destdir="${build.dir}" target="1.7" source="1.7" includeantruntime="false">
+			<src path="${src.dir}" />
+		</javac>
+	</target>
+
+	<target name="package" depends="compile" description="Package">
+		<jar destfile="${dist.dir}/${dist.jarname}" basedir="${build.dir}">
+			<manifest>
+				<attribute name="Main-Class" value="${manifest.mainclass}" />
+			</manifest>
+			<zipfileset dir="${basedir}" includes="LICENSE" fullpath="LICENSE" />
+		</jar>
+	</target>
+
+	<target name="main" depends="package" description="Main task">
+	</target>
+</project>


### PR DESCRIPTION
Thought it might be easier to maintain as the project gets bigger. Should be a "port" of the existing shell scripts; compiles the files, sets the manifest main class, and includes the license. Tested on my local machine (debian wheezy), seems to work.

So the targets are: clean, prepare, compile, package, and main (same as package for now)
