### PR TITLE
Fix wrong parsing of primitive multidimensional array parameters

### DIFF
--- a/src/main/java/bspkrs/mmv/ExcData.java
+++ b/src/main/java/bspkrs/mmv/ExcData.java
@@ -99,7 +99,7 @@ public class ExcData implements Comparable<ExcData>
 
     public static String[] splitMethodDesc(String desc)
     {
-        //\[*L[^;]+;|\[[ZBCSIFDJ]|[ZBCSIFDJ]
+        //\[*(?:L[^;]+;|[ZBCSIFDJ])
         int beginIndex = desc.indexOf('(');
         int endIndex = desc.lastIndexOf(')');
         if (((beginIndex == -1) && (endIndex != -1)) || ((beginIndex != -1) && (endIndex == -1)))
@@ -117,7 +117,7 @@ public class ExcData implements Comparable<ExcData>
         {
             x0 = desc.substring(beginIndex + 1, endIndex);
         }
-        Pattern pattern = Pattern.compile("\\[*L[^;]+;|\\[[ZBCSIFDJ]|[ZBCSIFDJ]");
+        Pattern pattern = Pattern.compile("\\[*(?:L[^;]+;|[ZBCSIFDJ])");
         Matcher matcher = pattern.matcher(x0);
 
         ArrayList<String> listMatches = new ArrayList<String>();


### PR DESCRIPTION
The regex for parsing method parameters has a small bug that causes primitive arrays to always be read as one-dimensional arrays, even if they have more dimensions. In addition, a redundant part was optimised.

Old regex: https://regex101.com/r/c34Rjs/1
New regex: https://regex101.com/r/3fbPGd/1