### PR TITLE
Replace http://export.mcpbot.bspk.rs URLs with MinecraftForge Maven URLs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'edu.sc.seis.launch4j' version '2.5.0'
 }
 
-version = '1.0.2'
+version = '1.0.3'
 ext.mainClassName = "bspkrs.mmv.gui.MappingGui"
 
 java {

--- a/src/main/java/bspkrs/mmv/McpMappingLoader.java
+++ b/src/main/java/bspkrs/mmv/McpMappingLoader.java
@@ -51,8 +51,8 @@ public class McpMappingLoader
     private final File                                   baseDir                 = new File(new File(System.getProperty("user.home")), ".cache/MCPMappingViewer");
     private final String                                 baseSrgDir              = "{mc_ver}";
     private final String                                 baseMappingDir          = "{mc_ver}/{channel}_{map_ver}";
-    private final String                                 baseMappingUrl          = "http://export.mcpbot.bspk.rs/mcp_{channel}/{map_ver}-{mc_ver}/mcp_{channel}-{map_ver}-{mc_ver}.zip";
-    private final String                                 newBaseSrgUrl           = "https://files.minecraftforge.net/maven/de/oceanlabs/mcp/mcp_config/{mc_ver}/mcp_config-{mc_ver}.zip";
+    private final String                                 baseMappingUrl          = "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_{channel}/{map_ver}-{mc_ver}/mcp_{channel}-{map_ver}-{mc_ver}.zip";
+    private final String                                 newBaseSrgUrl           = "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_config/{mc_ver}/mcp_config-{mc_ver}.zip";
     private final String                                 oldBaseSrgUrl           = "http://export.mcpbot.bspk.rs/mcp/{mc_ver}/mcp-{mc_ver}-srg.zip";
 
     private final File                                   srgDir;

--- a/src/main/java/bspkrs/mmv/McpMappingLoader.java
+++ b/src/main/java/bspkrs/mmv/McpMappingLoader.java
@@ -53,7 +53,7 @@ public class McpMappingLoader
     private final String                                 baseMappingDir          = "{mc_ver}/{channel}_{map_ver}";
     private final String                                 baseMappingUrl          = "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_{channel}/{map_ver}-{mc_ver}/mcp_{channel}-{map_ver}-{mc_ver}.zip";
     private final String                                 newBaseSrgUrl           = "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_config/{mc_ver}/mcp_config-{mc_ver}.zip";
-    private final String                                 oldBaseSrgUrl           = "http://export.mcpbot.bspk.rs/mcp/{mc_ver}/mcp-{mc_ver}-srg.zip";
+    private final String                                 oldBaseSrgUrl           = "https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/{mc_ver}/mcp-{mc_ver}-srg.zip";
 
     private final File                                   srgDir;
     private final File                                   mappingDir;

--- a/src/main/java/bspkrs/mmv/VersionFetcher.java
+++ b/src/main/java/bspkrs/mmv/VersionFetcher.java
@@ -29,7 +29,7 @@ import com.google.gson.Gson;
 
 public class VersionFetcher
 {
-    private final String jsonUrl = "http://export.mcpbot.bspk.rs/versions.json";
+    private final String jsonUrl = "https://maven.minecraftforge.net/de/oceanlabs/mcp/versions.json";
     private List<String> versions;
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Because MCPBot was shut down, this tool was not able to fetch any data anymore. This PR fixes this by now fetching data from the MinecraftForge maven.